### PR TITLE
Removing absolute Positioning if Inputfield

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -25,9 +25,6 @@
 			"scripts": [
 				"resources/ext.filterspecialpages.js"
 			],
-			"styles": [
-				"resources/ext.filterspecialpages.css"
-			],
 			"messages": [
 				"filterspecialpages-hint-label"
 			],

--- a/resources/ext.filterspecialpages.css
+++ b/resources/ext.filterspecialpages.css
@@ -1,9 +1,0 @@
-#bodyContent{
-	position: relative;
-}
-#filterspecialpages{
-	position: absolute;
-	top: 10px;
-	right: 0;
-	width: 400px;
-}

--- a/resources/ext.filterspecialpages.js
+++ b/resources/ext.filterspecialpages.js
@@ -11,7 +11,7 @@
 		"id": "filterspecialpages",
 		"name": "filterspecialpages"
 	} );
-	$( '#bodyContent' ).append( filterInput.$element );
+	$( '#bodyContent' ).prepend( filterInput.$element );
 	filterInput.focus();
 	filterInput.on( 'change', function ( value ) {
 		if ( value.length === 0 ) {


### PR DESCRIPTION
The CSS for this extension had hardcoded positioning
for mediawiki vector skin. This made problems with other skins,
when scaling the font and on small mobile devices.